### PR TITLE
Fix gpt-5-nano parameter handling and token usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -186,23 +186,30 @@ with st.sidebar:
     
     # Paramètres de génération
     st.subheader("🎛️ Paramètres")
-    
+
     # Paramètres spécifiques pour GPT-5
     if selected_model.startswith("gpt-5"):
         st.markdown("### 🧠 Paramètres GPT-5")
-        
+
+        is_nano = selected_model == "gpt-5-nano"
+
+        if is_nano:
+            st.info("💡 Le modèle gpt-5-nano est optimisé pour des réponses rapides et utilise un raisonnement minimal.")
+
         reasoning_effort = st.select_slider(
             "Reasoning Effort",
             options=["minimal", "low", "medium", "high"],
-            value="medium",
-            help="Niveau de raisonnement du modèle"
+            value="minimal" if is_nano else "medium",
+            help="Niveau de raisonnement du modèle",
+            disabled=is_nano
         )
-        
+
         verbosity = st.select_slider(
             "Verbosity",
             options=["low", "medium", "high"],
-            value="medium",
-            help="Niveau de détail des réponses"
+            value="low" if is_nano else "medium",
+            help="Niveau de détail des réponses",
+            disabled=is_nano
         )
         
         # Temperature seulement en mode minimal

--- a/ia_provider/gpt5.py
+++ b/ia_provider/gpt5.py
@@ -59,15 +59,19 @@ class GPT5Provider(BaseProvider):
         # Initialiser les paramètres
         params = {}
         
-        # GPT-5 utilise max_completion_tokens (comme GPT-4.1), pas max_tokens
+        # GPT-5 utilise directement 'max_tokens'
         if 'max_tokens' in kwargs:
-            params['max_completion_tokens'] = kwargs['max_tokens']
+            params['max_tokens'] = kwargs['max_tokens']
         else:
-            params['max_completion_tokens'] = self.default_params.get('max_tokens', 1000)
+            params['max_tokens'] = self.default_params.get('max_tokens', 1000)
         
         # Ajouter les paramètres spécifiques à GPT-5
         params['reasoning_effort'] = kwargs.get('reasoning_effort', self.gpt5_defaults['reasoning_effort'])
         params['verbosity'] = kwargs.get('verbosity', self.gpt5_defaults['verbosity'])
+
+        # Forcer le raisonnement minimal pour gpt-5-nano
+        if self.model_name == 'gpt-5-nano':
+            params['reasoning_effort'] = 'minimal'
         
         # En mode minimal, on peut utiliser temperature et autres paramètres classiques
         if params['reasoning_effort'] == 'minimal':
@@ -116,18 +120,13 @@ class GPT5Provider(BaseProvider):
             
         except Exception as e:
             error_str = str(e)
-            
-            # Gérer les erreurs spécifiques
-            if "max_tokens" in error_str and "max_completion_tokens" in error_str:
-                # Cette erreur ne devrait plus arriver avec notre correction
-                raise APIError(f"Erreur de paramètre GPT-5: utilisez max_tokens dans l'appel, il sera converti en max_completion_tokens automatiquement")
-            
+
             # Si les paramètres reasoning_effort/verbosity ne sont pas supportés (fallback pour compatibilité)
             if "reasoning_effort" in error_str or "verbosity" in error_str:
                 # Certains modèles pourraient ne pas supporter ces paramètres
                 # Essayer sans ces paramètres
                 params_fallback = {
-                    'max_completion_tokens': params.get('max_completion_tokens', 1000)
+                    'max_tokens': params.get('max_tokens', 1000)
                 }
                 
                 # Si on était en mode minimal, ajouter les paramètres classiques
@@ -179,15 +178,11 @@ class GPT5Provider(BaseProvider):
             
         except Exception as e:
             error_str = str(e)
-            
-            # Gérer les erreurs de paramètres
-            if "max_tokens" in error_str and "max_completion_tokens" in error_str:
-                raise APIError(f"Erreur de paramètre GPT-5: utilisez max_tokens dans l'appel, il sera converti en max_completion_tokens automatiquement")
-            
+
             # Fallback sans paramètres GPT-5 si nécessaire
             if "reasoning_effort" in error_str or "verbosity" in error_str:
                 params_fallback = {
-                    'max_completion_tokens': params.get('max_completion_tokens', 1000)
+                    'max_tokens': params.get('max_tokens', 1000)
                 }
                 
                 # Si on était en mode minimal, ajouter les paramètres classiques

--- a/test_ia_provider.py
+++ b/test_ia_provider.py
@@ -21,6 +21,7 @@ from ia_provider import (
 )
 from ia_provider.openai import OpenAIProvider
 from ia_provider.anthropic import AnthropicProvider
+from ia_provider.gpt5 import GPT5Provider
 
 
 # =============================================================================
@@ -58,17 +59,13 @@ class TestProviderManager:
     """Tests pour le gestionnaire de providers."""
     
     def test_available_models(self):
-        """Test que seuls les 2 modèles sont disponibles."""
+        """Test que les principaux modèles sont disponibles."""
         models = manager.get_available_models()
-        
-        assert len(models) == 2
+
         assert "gpt-4.1" in models
-        assert "claude-sonnet-4" in models
-        
-        # Vérifier qu'aucun autre modèle n'est présent
-        assert "gpt-4" not in models
-        assert "claude-3-opus" not in models
-        assert "gemini-pro" not in models
+        assert "gpt-5" in models
+        assert "gpt-5-nano" in models
+        assert "claude-sonnet-4-20250514" in models
     
     @patch('ia_provider.openai.openai')
     def test_get_provider_gpt41(self, mock_openai):
@@ -82,10 +79,10 @@ class TestProviderManager:
     @patch('ia_provider.anthropic.anthropic')
     def test_get_provider_claude(self, mock_anthropic):
         """Test de récupération du provider Claude."""
-        provider = manager.get_provider("claude-sonnet-4", "test-key")
-        
+        provider = manager.get_provider("claude-sonnet-4-20250514", "test-key")
+
         assert isinstance(provider, AnthropicProvider)
-        assert provider.model_name == "claude-sonnet-4"
+        assert provider.model_name == "claude-sonnet-4-20250514"
         assert provider.api_key == "test-key"
     
     def test_get_provider_unknown_model(self):
@@ -218,6 +215,37 @@ class TestOpenAIProvider:
 
 
 # =============================================================================
+# Tests du provider GPT-5
+# =============================================================================
+
+class TestGPT5Provider:
+    """Tests pour le provider GPT-5."""
+
+    @patch('ia_provider.gpt5.openai')
+    def test_gpt5_nano_parameter_override(self, mock_openai):
+        """Vérifie que gpt-5-nano force les bons paramètres."""
+
+        mock_client = MagicMock()
+        mock_openai.OpenAI.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Test OK"))]
+        mock_client.chat.completions.create.return_value = mock_response
+
+        provider = GPT5Provider("gpt-5-nano", "test-key")
+
+        provider.generer_reponse(
+            "Test",
+            reasoning_effort="high",
+            verbosity="high",
+            max_tokens=123,
+        )
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs.get('reasoning_effort') == 'minimal'
+        assert 'max_completion_tokens' not in call_kwargs
+        assert call_kwargs.get('max_tokens') == 123
+
+# =============================================================================
 # Tests du provider Anthropic (Claude Sonnet 4)
 # =============================================================================
 
@@ -233,7 +261,7 @@ class TestAnthropicProvider:
     
     def test_thinking_parameter(self, mock_anthropic):
         """Test du support du mode thinking."""
-        provider = AnthropicProvider("claude-sonnet-4", "test-key")
+        provider = AnthropicProvider("claude-sonnet-4-20250514", "test-key")
         
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text="Réponse avec thinking")]
@@ -253,7 +281,7 @@ class TestAnthropicProvider:
     
     def test_max_tokens_always_present(self, mock_anthropic):
         """Test que max_tokens est toujours ajouté."""
-        provider = AnthropicProvider("claude-sonnet-4", "test-key")
+        provider = AnthropicProvider("claude-sonnet-4-20250514", "test-key")
         
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text="Test")]
@@ -268,7 +296,7 @@ class TestAnthropicProvider:
     
     def test_generer_reponse_success(self, mock_anthropic):
         """Test de génération réussie."""
-        provider = AnthropicProvider("claude-sonnet-4", "test-key")
+        provider = AnthropicProvider("claude-sonnet-4-20250514", "test-key")
         
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text="Réponse Claude")]
@@ -283,12 +311,12 @@ class TestAnthropicProvider:
         assert response == "Réponse Claude"
         
         call_kwargs = provider.client.messages.create.call_args[1]
-        assert call_kwargs['model'] == "claude-sonnet-4"
+        assert call_kwargs['model'] == "claude-sonnet-4-20250514"
         assert call_kwargs['max_tokens'] == 250
     
     def test_chatter_validates_roles(self, mock_anthropic):
         """Test de validation des rôles."""
-        provider = AnthropicProvider("claude-sonnet-4", "test-key")
+        provider = AnthropicProvider("claude-sonnet-4-20250514", "test-key")
         
         invalid_messages = [{"role": "system", "content": "Test"}]
         
@@ -306,12 +334,12 @@ class TestIntegration:
     def test_both_models_registered(self):
         """Test que les deux modèles sont bien enregistrés."""
         providers_info = manager.get_providers_info()
-        
+
         assert 'OpenAIProvider' in providers_info
         assert 'AnthropicProvider' in providers_info
-        
+
         assert 'gpt-4.1' in providers_info['OpenAIProvider']
-        assert 'claude-sonnet-4' in providers_info['AnthropicProvider']
+        assert 'claude-sonnet-4-20250514' in providers_info['AnthropicProvider']
     
     @patch('ia_provider.openai.openai')
     @patch('ia_provider.anthropic.anthropic')
@@ -322,7 +350,7 @@ class TestIntegration:
         assert isinstance(provider1, OpenAIProvider)
         
         # Test Claude
-        provider2 = manager.get_provider("claude-sonnet-4", "key2")
+        provider2 = manager.get_provider("claude-sonnet-4-20250514", "key2")
         assert isinstance(provider2, AnthropicProvider)
         
         # Vérifier que ce sont bien des instances différentes


### PR DESCRIPTION
## Summary
- Ensure GPT-5 provider uses `max_tokens` and enforces minimal reasoning for `gpt-5-nano`
- Disable reasoning effort and verbosity controls in the UI for `gpt-5-nano`
- Add tests validating parameter overrides and correct token forwarding

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aa27fec93c832bb5f22626a60553e2