### PR TITLE
Avoid temperature parameter for gpt-5-nano

### DIFF
--- a/ia_provider/gpt5.py
+++ b/ia_provider/gpt5.py
@@ -75,15 +75,16 @@ class GPT5Provider(BaseProvider):
         
         # En mode minimal, on peut utiliser temperature et autres paramètres classiques
         if params['reasoning_effort'] == 'minimal':
-            # En mode minimal, on peut utiliser les paramètres classiques
-            if 'temperature' in kwargs:
-                params['temperature'] = kwargs['temperature']
-            if 'top_p' in kwargs:
-                params['top_p'] = kwargs['top_p']
-            if 'frequency_penalty' in kwargs:
-                params['frequency_penalty'] = kwargs['frequency_penalty']
-            if 'presence_penalty' in kwargs:
-                params['presence_penalty'] = kwargs['presence_penalty']
+            # N'ajouter ces paramètres que si le modèle n'est pas gpt-5-nano
+            if self.model_name != 'gpt-5-nano':
+                if 'temperature' in kwargs:
+                    params['temperature'] = kwargs['temperature']
+                if 'top_p' in kwargs:
+                    params['top_p'] = kwargs['top_p']
+                if 'frequency_penalty' in kwargs:
+                    params['frequency_penalty'] = kwargs['frequency_penalty']
+                if 'presence_penalty' in kwargs:
+                    params['presence_penalty'] = kwargs['presence_penalty']
         # Sinon, en mode raisonnement (low, medium, high), ces paramètres sont ignorés
         
         # Filtrer les paramètres None

--- a/test_ia_provider.py
+++ b/test_ia_provider.py
@@ -241,12 +241,14 @@ class TestGPT5Provider:
             reasoning_effort="high",  # Doit être ignoré
             verbosity="high",
             max_tokens=123,
+            temperature=0.7  # Ce paramètre devrait être ignoré
         )
 
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs.get('reasoning_effort') == 'minimal'
         assert 'max_tokens' not in call_kwargs
         assert call_kwargs.get('max_completion_tokens') == 123
+        assert 'temperature' not in call_kwargs
 
 # =============================================================================
 # Tests du provider Anthropic (Claude Sonnet 4)


### PR DESCRIPTION
## Summary
- Ensure `_preparer_parametres_gpt5` skips classic tuning parameters when the model is `gpt-5-nano`
- Extend unit test to confirm temperature is filtered out for `gpt-5-nano`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aa6899eb9c832ba0ccc157bb1e8cc7